### PR TITLE
Add Email to Info Section

### DIFF
--- a/app/partials/info.handlebars
+++ b/app/partials/info.handlebars
@@ -5,6 +5,7 @@
   <div class="info-meta">
     <div class="location">
       <span class="contact">{{basics.phone}}</span>
+      <span class="email">{{basics.email}}</span>
       <span class="region">{{basics.location.city}}, {{basics.location.region}}</span>
     </div>
     <div class="social">


### PR DESCRIPTION
Email is included in resume-example.json but not loaded in to the partial/info.handlebars to be rendered on the page.
